### PR TITLE
refactor:重构comment结构

### DIFF
--- a/internal/converter/comment.go
+++ b/internal/converter/comment.go
@@ -38,9 +38,9 @@ func ToCommentResp(d model.CommentDetail) resp.CommentResp {
 	} else {
 		res.IsLike = "false"
 	}
-	res.Creator.StudentID = d.Creator.StudentID
-	res.Creator.Username = d.Creator.Name
-	res.Creator.Avatar = d.Creator.Avatar
+	res.Creator.StudentID = cmt.StudentID
+	res.Creator.Username = cmt.CreatorName
+	res.Creator.Avatar = cmt.CreatorAvatar
 	for _, reply := range d.Replies {
 		res.Reply = append(res.Reply, ToReplyResp(reply))
 	}
@@ -64,7 +64,7 @@ func ToReplyResp(d model.ReplyDetail) resp.ReplyResp {
 		ReplyPos:       cmt.Position,
 		ParentID:       cmt.ParentID,
 		RootID:         cmt.RootID,
-		ParentUserName: d.ParentUserName,
+		ParentUserName: cmt.ReplyToUserName,
 		LikeNum:        cmt.LikeNum,
 		ReplyNum:       cmt.ReplyNum,
 	}
@@ -73,8 +73,8 @@ func ToReplyResp(d model.ReplyDetail) resp.ReplyResp {
 	} else {
 		res.IsLike = "false"
 	}
-	res.ReplyCreator.StudentID = d.Creator.StudentID
-	res.ReplyCreator.Username = d.Creator.Name
-	res.ReplyCreator.Avatar = d.Creator.Avatar
+	res.ReplyCreator.StudentID = cmt.StudentID
+	res.ReplyCreator.Username = cmt.CreatorName
+	res.ReplyCreator.Avatar = cmt.CreatorAvatar
 	return res
 }

--- a/internal/dao/comment.go
+++ b/internal/dao/comment.go
@@ -15,6 +15,8 @@ type CommentDaoHdl interface {
 	AnswerComment(context.Context, *model.Comment) error
 	LoadComments(context.Context, string) ([]model.Comment, error)
 	LoadAnswers(context.Context, string) ([]model.Comment, error)
+	FindCmtByID(context.Context, string) *model.Comment
+	DecrementReplyNum(context.Context, string) error
 }
 
 type CommentDao struct {
@@ -59,4 +61,9 @@ func (cd *CommentDao) FindCmtByID(c context.Context, cid string) *model.Comment 
 		return nil
 	}
 	return &cmt
+}
+
+func (cd *CommentDao) DecrementReplyNum(c context.Context, bid string) error {
+	return cd.db.WithContext(c).Model(&model.Comment{}).Where("bid = ?", bid).
+		Update("reply_num", gorm.Expr("reply_num - 1")).Error
 }

--- a/internal/dao/user.go
+++ b/internal/dao/user.go
@@ -18,6 +18,7 @@ type UserDaoHdl interface {
 	GetUserInfo(context.Context, string) (model.User, error)
 	FindUserByID(context.Context, string) model.User
 	UpdateCollege(context.Context, string, string) error
+	GetUsersByIDs(ctx context.Context, ids []string) ([]model.User, error)
 }
 
 type UserDao struct {
@@ -70,4 +71,10 @@ func (ud *UserDao) UpdateCollege(ctx context.Context, studentID string, college 
 
 func (ud *UserDao) UpdateRealName(ctx context.Context, studentID string, realName string) error {
 	return ud.db.WithContext(ctx).Model(&model.User{}).Where("student_id = ?", studentID).Update("real_name", realName).Error
+}
+
+func (ud *UserDao) GetUsersByIDs(ctx context.Context, ids []string) ([]model.User, error) {
+	var users []model.User
+	err := ud.db.WithContext(ctx).Where("student_id IN ?", ids).Find(&users).Error
+	return users, err
 }

--- a/internal/model/comment.go
+++ b/internal/model/comment.go
@@ -15,6 +15,13 @@ type Comment struct {
 
 	LikeNum  int `gorm:"not null;default:0;comment:点赞数;column:like_num"`
 	ReplyNum int `gorm:"not null;default:0;comment:回复数;column:reply_num"`
+
+	CreatorName     string `gorm:"type:varchar(255);comment:评论者名称快照;column:creator_name"`
+	CreatorAvatar   string `gorm:"type:varchar(255);comment:评论者头像快照;column:creator_avatar"`
+	ReplyToUserID   string `gorm:"type:varchar(255);comment:被回复者ID;column:reply_to_user_id"`
+	ReplyToUserName string `gorm:"type:varchar(255);comment:被回复者名称;column:reply_to_user_name"`
+	RootObjectID    string `gorm:"type:varchar(255);comment:根对象ID;column:root_object_id"`
+	RootObjectType  string `gorm:"type:varchar(255);comment:根对象类型;column:root_object_type"`
 }
 
 type CommentDetail struct {

--- a/internal/repo/user.go
+++ b/internal/repo/user.go
@@ -34,17 +34,22 @@ func (r *UserRepo) CheckUserExist(ctx context.Context, studentID string) bool {
 }
 
 func (r *UserRepo) GetUserInfo(ctx context.Context, studentID string) (model.User, error) {
-	//return cache.GetTyped(r.ch, ctx, r.userInfoKey(studentID), 10*time.Minute, func(context.Context) (model.User, error) {
-	//	user, err := r.dao.GetUserInfo(ctx, studentID)
-	//	if err != nil {
-	//		if errors.Is(err, gorm.ErrRecordNotFound) {
-	//			return model.User{}, cache.MarkNotFound(err)
-	//		}
-	//		return model.User{}, err
-	//	}
-	//	return user, nil
-	//})
 	return r.dao.GetUserInfo(ctx, studentID)
+}
+
+func (r *UserRepo) GetUsersByIDs(ctx context.Context, ids []string) (map[string]*model.User, error) {
+	if len(ids) == 0 {
+		return make(map[string]*model.User), nil
+	}
+	users, err := r.dao.GetUsersByIDs(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*model.User, len(users))
+	for i := range users {
+		result[users[i].StudentID] = &users[i]
+	}
+	return result, nil
 }
 
 func (r *UserRepo) FindUserByID(ctx context.Context, studentID string) model.User {

--- a/internal/service/comment.go
+++ b/internal/service/comment.go
@@ -3,13 +3,13 @@ package service
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/raiki02/EG/internal/dao"
 	"github.com/raiki02/EG/internal/model"
 	"github.com/raiki02/EG/internal/mq"
 	"github.com/raiki02/EG/internal/repo"
 	"github.com/raiki02/EG/pkg/logger"
+	"github.com/raiki02/EG/pkg/utils"
 	"go.uber.org/zap"
 )
 
@@ -46,20 +46,31 @@ func NewCommentService(cd *dao.CommentDao, ud *repo.UserRepo, id *repo.Interacti
 }
 
 func (cs *CommentService) CreateComment(c context.Context, cmt *model.Comment, studentID string) (*model.Comment, error) {
-	rootID := ""
-	rootType := ""
+	creator, err := cs.ud.GetUserInfo(c, studentID)
+	if err != nil {
+		cs.l.Error("Error get user info failed", zap.Error(err), zap.String("studentID", studentID))
+		return nil, err
+	}
+	cmt.CreatorName = creator.Name
+	cmt.CreatorAvatar = creator.Avatar
+
 	if cmt.Subject == SubjectComment {
-		rootCommentID, resolvedRootID, resolvedRootType, resolveErr := cs.resolveCommentRootMeta(c, cmt.ParentID)
-		if resolveErr != nil {
-			cs.l.Error("Error resolve comment root meta failed", zap.Error(resolveErr), zap.String("parentID", cmt.ParentID))
-			return nil, resolveErr
+		parent := cs.cd.FindCmtByID(c, cmt.ParentID)
+		if parent == nil {
+			return nil, errors.New("comment parent not found")
 		}
-		cmt.RootID = rootCommentID
-		rootID = resolvedRootID
-		rootType = resolvedRootType
+		cmt.RootID = parent.Bid
+		cmt.RootObjectID = parent.RootObjectID
+		cmt.RootObjectType = parent.RootObjectType
+	} else {
+		cmt.RootObjectID = cmt.ParentID
+		cmt.RootObjectType = cmt.Subject
 	}
 
-	err := cs.cd.CreateComment(c, cmt)
+	rootID := cmt.RootObjectID
+	rootType := cmt.RootObjectType
+
+	err = cs.cd.CreateComment(c, cmt)
 	cs.l.Info("CreateComment",
 		zap.String("bid", cmt.Bid),
 		zap.String("studentid", cmt.StudentID),
@@ -115,21 +126,36 @@ func (cs *CommentService) CreateComment(c context.Context, cmt *model.Comment, s
 }
 
 func (cs *CommentService) DeleteComment(c context.Context, targetID, studentID string) error {
-	err := cs.cd.DeleteComment(c, studentID, targetID)
-	if err != nil {
-		cs.l.Error("Error comment delete failed", zap.Error(err))
-		return err
+	cmt := cs.cd.FindCmtByID(c, targetID)
+	if cmt != nil && cmt.Subject == SubjectComment && cmt.RootID != "" {
+		if err := cs.cd.DecrementReplyNum(c, cmt.RootID); err != nil {
+			cs.l.Error("Error decrement reply num", zap.Error(err))
+		}
 	}
-	return nil
+	return cs.cd.DeleteComment(c, studentID, targetID)
 }
 
 func (cs *CommentService) AnswerComment(c context.Context, cmt *model.Comment, studentID string) (*model.Comment, error) {
-	rootCommentID, rootID, rootType, err := cs.resolveCommentRootMeta(c, cmt.ParentID)
+	creator, err := cs.ud.GetUserInfo(c, studentID)
 	if err != nil {
-		cs.l.Error("Error resolve comment root meta failed", zap.Error(err), zap.String("parentID", cmt.ParentID))
+		cs.l.Error("Error get user info failed", zap.Error(err), zap.String("studentID", studentID))
 		return nil, err
 	}
-	cmt.RootID = rootCommentID
+	cmt.CreatorName = creator.Name
+	cmt.CreatorAvatar = creator.Avatar
+
+	parentCmt := cs.cd.FindCmtByID(c, cmt.ParentID)
+	if parentCmt == nil {
+		return nil, errors.New("comment parent not found")
+	}
+	cmt.RootID = parentCmt.Bid
+	cmt.RootObjectID = parentCmt.RootObjectID
+	cmt.RootObjectType = parentCmt.RootObjectType
+	cmt.ReplyToUserID = parentCmt.StudentID
+	cmt.ReplyToUserName = parentCmt.CreatorName
+
+	rootID := parentCmt.RootObjectID
+	rootType := parentCmt.RootObjectType
 
 	err = cs.cd.AnswerComment(c, cmt)
 	if err != nil {
@@ -223,32 +249,54 @@ func (cs *CommentService) LoadComments(c context.Context, parentID string) ([]mo
 }
 
 func (cs *CommentService) EnrichComments(c context.Context, cmts []model.Comment, viewerID string) []model.CommentDetail {
+	if len(cmts) == 0 {
+		return nil
+	}
+
+	idSet := make(map[string]struct{})
+	idSet[viewerID] = struct{}{}
+	for _, cmt := range cmts {
+		idSet[cmt.StudentID] = struct{}{}
+	}
+
+	for _, cmt := range cmts {
+		replies, _ := cs.cd.LoadAnswers(c, cmt.Bid)
+		for _, reply := range replies {
+			idSet[reply.StudentID] = struct{}{}
+		}
+	}
+
+	idList := make([]string, 0, len(idSet))
+	for id := range idSet {
+		idList = append(idList, id)
+	}
+	userMap, err := cs.ud.GetUsersByIDs(c, idList)
+	if err != nil {
+		cs.l.Error("Error batch get users", zap.Error(err))
+	}
+
 	details := make([]model.CommentDetail, 0, len(cmts))
 	for i := range cmts {
-		details = append(details, cs.enrichComment(c, &cmts[i], viewerID))
+		details = append(details, cs.enrichCommentWithCache(c, &cmts[i], viewerID, userMap))
 	}
 	return details
 }
 
 func (cs *CommentService) EnrichComment(c context.Context, cmt *model.Comment, viewerID string) model.CommentDetail {
-	return cs.enrichComment(c, cmt, viewerID)
+	idList := []string{viewerID, cmt.StudentID}
+	userMap, _ := cs.ud.GetUsersByIDs(c, idList)
+	return cs.enrichCommentWithCache(c, cmt, viewerID, userMap)
 }
 
 func (cs *CommentService) EnrichReply(c context.Context, cmt *model.Comment, viewerID string) model.ReplyDetail {
-	return cs.enrichReply(c, cmt, viewerID)
+	idList := []string{viewerID, cmt.StudentID}
+	userMap, _ := cs.ud.GetUsersByIDs(c, idList)
+	return cs.enrichReplyWithCache(c, cmt, viewerID, userMap)
 }
 
-func (cs *CommentService) enrichComment(c context.Context, cmt *model.Comment, viewerID string) model.CommentDetail {
-	user, err := cs.ud.GetUserInfo(c, cmt.StudentID)
-	if err != nil {
-		cs.l.Error("Error get user info when enriching comment", zap.Error(err))
-		return model.CommentDetail{}
-	}
-	searcher, err := cs.ud.GetUserInfo(c, viewerID)
-	if err != nil {
-		cs.l.Error("Error get user info when enriching comment", zap.Error(err))
-		return model.CommentDetail{}
-	}
+func (cs *CommentService) enrichCommentWithCache(c context.Context, cmt *model.Comment, viewerID string, userMap map[string]*model.User) model.CommentDetail {
+	creator := userMap[cmt.StudentID]
+	viewer := userMap[viewerID]
 
 	replies, err := cs.cd.LoadAnswers(c, cmt.Bid)
 	if err != nil {
@@ -258,51 +306,35 @@ func (cs *CommentService) enrichComment(c context.Context, cmt *model.Comment, v
 
 	detail := model.CommentDetail{
 		Comment: *cmt,
-		Creator: model.UserBrief{
-			StudentID: user.StudentID,
-			Name:      user.Name,
-			Avatar:    user.Avatar,
-		},
-		IsLike: strings.Contains(searcher.LikeComment, cmt.Bid),
+	}
+	if creator != nil {
+		detail.Creator = model.UserBrief{
+			StudentID: creator.StudentID,
+			Name:      creator.Name,
+			Avatar:    creator.Avatar,
+		}
+	}
+	if viewer != nil {
+		detail.IsLike = utils.HasLike(viewer.LikeComment, cmt.Bid)
 	}
 	for _, reply := range replies {
-		detail.Replies = append(detail.Replies, cs.enrichReply(c, &reply, viewerID))
+		detail.Replies = append(detail.Replies, cs.enrichReplyWithCache(c, &reply, viewerID, userMap))
 	}
 	return detail
 }
 
-func (cs *CommentService) enrichReply(c context.Context, cmt *model.Comment, viewerID string) model.ReplyDetail {
-	user, err := cs.ud.GetUserInfo(c, cmt.StudentID)
-	if err != nil {
-		cs.l.Error("Error get user info when enriching reply", zap.Error(err))
-		return model.ReplyDetail{}
-	}
-	searcher, err := cs.ud.GetUserInfo(c, viewerID)
-	if err != nil {
-		cs.l.Error("Error get user info when enriching reply", zap.Error(err))
-		return model.ReplyDetail{}
-	}
+func (cs *CommentService) enrichReplyWithCache(c context.Context, cmt *model.Comment, viewerID string, userMap map[string]*model.User) model.ReplyDetail {
+	viewer := userMap[viewerID]
 
-	pc := cs.cd.FindCmtByID(c, cmt.ParentID)
-	if pc == nil {
-		cs.l.Error("Error find comment by id", zap.String("pid", cmt.ParentID))
-		return model.ReplyDetail{}
-	}
-	pu, err := cs.ud.GetUserInfo(c, pc.StudentID)
-	if err != nil {
-		cs.l.Error("Error get user info when enriching reply", zap.Error(err))
-		return model.ReplyDetail{}
+	isLike := false
+	if viewer != nil {
+		isLike = utils.HasLike(viewer.LikeComment, cmt.Bid)
 	}
 
 	return model.ReplyDetail{
-		Comment: *cmt,
-		Creator: model.UserBrief{
-			StudentID: user.StudentID,
-			Name:      user.Name,
-			Avatar:    user.Avatar,
-		},
-		ParentUserName: pu.Name,
-		IsLike:         strings.Contains(searcher.LikeComment, cmt.Bid),
+		Comment:        *cmt,
+		ParentUserName: cmt.ReplyToUserName,
+		IsLike:         isLike,
 	}
 }
 

--- a/internal/service/comment.go
+++ b/internal/service/comment.go
@@ -54,6 +54,7 @@ func (cs *CommentService) CreateComment(c context.Context, cmt *model.Comment, s
 	cmt.CreatorName = creator.Name
 	cmt.CreatorAvatar = creator.Avatar
 
+	var rootID, rootType string
 	if cmt.Subject == SubjectComment {
 		parent := cs.cd.FindCmtByID(c, cmt.ParentID)
 		if parent == nil {
@@ -62,13 +63,20 @@ func (cs *CommentService) CreateComment(c context.Context, cmt *model.Comment, s
 		cmt.RootID = parent.Bid
 		cmt.RootObjectID = parent.RootObjectID
 		cmt.RootObjectType = parent.RootObjectType
+		rootID = parent.RootObjectID
+		rootType = parent.RootObjectType
 	} else {
 		cmt.RootObjectID = cmt.ParentID
 		cmt.RootObjectType = cmt.Subject
+		rootID = cmt.ParentID
+		rootType = cmt.Subject
 	}
 
-	rootID := cmt.RootObjectID
-	rootType := cmt.RootObjectType
+	subject, err := cs.sg.GetSubjectInfo(c, cmt.ParentID, cmt.Subject)
+	if err != nil {
+		cs.l.Error("Error get activity or post or comment failed", zap.Error(err))
+		return nil, err
+	}
 
 	err = cs.cd.CreateComment(c, cmt)
 	cs.l.Info("CreateComment",
@@ -78,12 +86,6 @@ func (cs *CommentService) CreateComment(c context.Context, cmt *model.Comment, s
 	)
 	if err != nil {
 		cs.l.Error("Error comment create failed", zap.Error(err))
-		return nil, err
-	}
-
-	subject, err := cs.sg.GetSubjectInfo(c, cmt.ParentID, cmt.Subject)
-	if err != nil {
-		cs.l.Error("Error get activity or post or comment failed", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,0 +1,16 @@
+package utils
+
+import "strings"
+
+func HasLike(likes string, bid string) bool {
+	if likes == "" || bid == "" {
+		return false
+	}
+	parts := strings.Split(likes, ",")
+	for _, p := range parts {
+		if p == bid {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
fix https://github.com/muxi-mini-project/2025-EventGlide-Backend/issues/25
解决以下问题：
1. 查询评论的时候存在N+1问题，要多次查找userid，改为批量查询减少MySQL的IO
2. like的判断存在问题，可能导致误判
3. 假如查一个人的回复，可能会多次getuserinfo，使用userCache := map[string]User{}
4. 这里for i := 0; i < 20; i++做了递归深度限制，使用数据库约束RootID直接保存，然后查询RootObjectID和RootObjectType
5. ReplyNum 更新逻辑不完整